### PR TITLE
Sync lib_ui with Telegram Desktop 7.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ PRIVATE
     fonts/fonts.qrc
     qt_conf/win.qrc
 
+    ayu/ayu_ui_settings.cpp
+    ayu/ayu_ui_settings.h
+
     ui/accessible/ui_accessible_factory.cpp
     ui/accessible/ui_accessible_factory.h
     ui/accessible/ui_accessible_item.cpp

--- a/ayu/ayu_ui_settings.cpp
+++ b/ayu/ayu_ui_settings.cpp
@@ -1,0 +1,58 @@
+// This is the source code of AyuGram for Desktop.
+//
+// We do not and cannot prevent the use of our code,
+// but be respectful and credit the original author.
+//
+// Copyright @Radolyn, 2026
+#include "ayu_ui_settings.h"
+
+#include <utility>
+
+namespace AyuUiSettings {
+
+QString monoFont;
+double wideMultiplier = 1.0;
+bool materialSwitches;
+int avatarCorners = kMaxAvatarCorners;
+
+void setMonoFont(QString newFont) {
+	monoFont = std::move(newFont);
+}
+
+QString getMonoFont() {
+	return monoFont;
+}
+
+void setWideMultiplier(double val) {
+	wideMultiplier = val;
+}
+
+bool isWideMultiplied() {
+	return abs(wideMultiplier - 1.0) > 0.01;
+}
+
+int getWideMultiplied(int width, double mult) {
+	if (!isWideMultiplied()) {
+		return width;
+	}
+	const auto res = width * (wideMultiplier * mult);
+	return std::max(width, static_cast<int>(std::round(res)));
+}
+
+void setMaterialSwitches(bool val) {
+	materialSwitches = val;
+}
+
+bool isMaterialSwitches() {
+	return materialSwitches;
+}
+
+void setAvatarCorners(int val) {
+	avatarCorners = val;
+}
+
+int getAvatarCorners() {
+	return avatarCorners;
+}
+
+}

--- a/ayu/ayu_ui_settings.h
+++ b/ayu/ayu_ui_settings.h
@@ -1,0 +1,27 @@
+// This is the source code of AyuGram for Desktop.
+//
+// We do not and cannot prevent the use of our code,
+// but be respectful and credit the original author.
+//
+// Copyright @Radolyn, 2026
+#pragma once
+
+namespace AyuUiSettings {
+
+inline constexpr int kMaxAvatarCorners = 23;
+
+void setMonoFont(QString newFont);
+QString getMonoFont();
+
+void setWideMultiplier(double val);
+
+bool isWideMultiplied();
+int getWideMultiplied(int width, double mult);
+
+void setMaterialSwitches(bool val);
+bool isMaterialSwitches();
+
+void setAvatarCorners(int val);
+int getAvatarCorners();
+
+}

--- a/ui/basic.style
+++ b/ui/basic.style
@@ -113,8 +113,8 @@ noContactsHeight: 100px;
 noContactsFont: font(fsize);
 noContactsColor: windowSubTextFg;
 
-activeFadeInDuration: 500;
-activeFadeOutDuration: 3000;
+activeFadeInDuration: 400;
+activeFadeOutDuration: 2000;
 
 smallCloseIcon: icon {{ "simple_close", smallCloseIconFg }};
 smallCloseIconOver: icon {{ "simple_close", smallCloseIconFgOver }};

--- a/ui/colors.palette
+++ b/ui/colors.palette
@@ -168,9 +168,9 @@ introBg: windowBg; // login background
 introTitleFg: windowBoldFg; // login title text
 introDescriptionFg: windowSubTextFg; // login description text
 
-introCoverTopBg: #0f89d0; // intro gradient top (from)
-introCoverBottomBg: #39b0f0; // intro gradient bottom (to)
-introCoverIconsFg: #5ec6ff; // intro cloud graphics
+introCoverTopBg: #2B2242; // intro gradient top (from)
+introCoverBottomBg: #2B2242; // intro gradient bottom (to)
+introCoverIconsFg: #FFFFFF; // intro cloud graphics
 introCoverPlaneTrace: #5ec6ff69; // intro plane traces
 introCoverPlaneInner: #c6d8e8; // intro plane part
 introCoverPlaneOuter: #a1bed4; // intro plane part

--- a/ui/effects/panel_animation.cpp
+++ b/ui/effects/panel_animation.cpp
@@ -307,10 +307,12 @@ void PanelAnimation::setAlphaDuration() {
 void PanelAnimation::start() {
 	Assert(!_finalImage.isNull());
 	RoundShadowAnimation::start(_finalWidth, _finalHeight, _finalImage.devicePixelRatio());
-	auto checkCorner = [this](const Corner &corner) {
+	auto maxCornerWidth = 0;
+	auto maxCornerHeight = 0;
+	auto checkCorner = [&](const Corner &corner) {
 		if (!corner.valid()) return;
-		if (_startWidth >= 0) Assert(corner.width <= _startWidth);
-		if (_startHeight >= 0) Assert(corner.height <= _startHeight);
+		maxCornerWidth = std::max(maxCornerWidth, corner.width);
+		maxCornerHeight = std::max(maxCornerHeight, corner.height);
 		Assert(corner.width <= _finalInnerWidth);
 		Assert(corner.height <= _finalInnerHeight);
 	};
@@ -318,6 +320,12 @@ void PanelAnimation::start() {
 	checkCorner(_topRight);
 	checkCorner(_bottomLeft);
 	checkCorner(_bottomRight);
+	if (_startWidth >= 0 && maxCornerWidth > _startWidth) {
+		_startWidth = -1;
+	}
+	if (_startHeight >= 0 && maxCornerHeight > _startHeight) {
+		_startHeight = -1;
+	}
 }
 
 auto PanelAnimation::computeState(float64 dt, float64 opacity) const

--- a/ui/image/image_prepare.cpp
+++ b/ui/image/image_prepare.cpp
@@ -14,6 +14,7 @@
 #include "base/bytes.h"
 #include "styles/palette.h"
 #include "styles/style_basic.h"
+#include "ayu/ayu_ui_settings.h"
 
 #include <zlib.h>
 #include <QtCore/QFile>
@@ -530,7 +531,8 @@ ReadResult Read(ReadArgs &&args) {
 		? Option::RoundLarge
 		: (radius == ImageRoundRadius::Small)
 		? Option::RoundSmall
-		: (radius == ImageRoundRadius::Ellipse)
+		: (radius == ImageRoundRadius::Ellipse
+			|| radius == ImageRoundRadius::AyuUserpic)
 		? Option::RoundCircle
 		: Option::None);
 }
@@ -1132,6 +1134,19 @@ QImage Round(
 		QRect target) {
 	if (!static_cast<int>(corners)) {
 		return std::move(image);
+	} else if (radius == ImageRoundRadius::AyuUserpic) {
+		const auto corners_val = AyuUiSettings::getAvatarCorners();
+		if (corners_val >= AyuUiSettings::kMaxAvatarCorners) {
+			return Circle(std::move(image), target);
+		} else if (corners_val <= 0) {
+			return std::move(image);
+		}
+		const auto size = target.isEmpty()
+			? std::min(image.width(), image.height())
+			: std::min(target.width(), target.height());
+		const auto r = int(double(corners_val) / AyuUiSettings::kMaxAvatarCorners * size / 2.0)
+			/ style::DevicePixelRatio();
+		return Round(std::move(image), CornersMask(r), corners, target);
 	} else if (radius == ImageRoundRadius::Ellipse) {
 		Assert((corners & RectPart::AllCorners) == RectPart::AllCorners);
 		return Circle(std::move(image), target);

--- a/ui/image/image_prepare.h
+++ b/ui/image/image_prepare.h
@@ -21,6 +21,7 @@ enum class ImageRoundRadius {
 	Large,
 	Small,
 	Ellipse,
+	AyuUserpic,
 };
 
 namespace Images {

--- a/ui/layers/layers.style
+++ b/ui/layers/layers.style
@@ -35,7 +35,7 @@ Box {
 }
 
 boxDuration: 200;
-boxRadius: 8px;
+boxRadius: 6px;
 
 boxButtonFont: font(boxFontSize semibold);
 defaultBoxButtonTextStyle: TextStyle(semiboldTextStyle) {

--- a/ui/style/style_core_font.cpp
+++ b/ui/style/style_core_font.cpp
@@ -21,6 +21,11 @@
 #include <glib.h>
 #endif // __has_include(<glib.h>)
 
+
+// AyuGram includes
+#include "ayu/ayu_ui_settings.h"
+
+
 void style_InitFontsResource() {
 #ifdef Q_OS_MAC // Use resources from the .app bundle on macOS.
 
@@ -122,7 +127,9 @@ bool LoadCustomFont(const QString &filePath) {
 }
 
 [[nodiscard]] QString ManualMonospaceFont() {
+	const auto monoFont = AyuUiSettings::getMonoFont().isEmpty() ? "Cascadia Mono"_q : AyuUiSettings::getMonoFont();
 	const auto kTryFirst = std::initializer_list<QString>{
+		monoFont,
 		u"Cascadia Mono"_q,
 		u"Consolas"_q,
 		u"Liberation Mono"_q,

--- a/ui/text/text.h
+++ b/ui/text/text.h
@@ -218,6 +218,7 @@ struct QuotePaintCache {
 	std::array<QColor, kMaxQuoteOutlines> outlines;
 	QColor header;
 	QColor bg;
+	QColor bg2;
 	QColor icon;
 };
 

--- a/ui/text/text_entity.h
+++ b/ui/text/text_entity.h
@@ -118,6 +118,12 @@ public:
 	[[nodiscard]] QString data() const {
 		return _data;
 	}
+	void setLocal() {
+		_local = true;
+	}
+	[[nodiscard]] bool isLocal() const {
+		return _local;
+	}
 
 	void extendToLeft(int extent) {
 		_offset -= extent;
@@ -165,6 +171,7 @@ public:
 
 private:
 	EntityType _type = EntityType::Invalid;
+	bool _local = false;
 	int _offset = 0;
 	int _length = 0;
 	QString _data;

--- a/ui/text/text_utilities.cpp
+++ b/ui/text/text_utilities.cpp
@@ -123,6 +123,10 @@ TextWithEntities StrikeOut(const QString &text) {
 	return WithSingleEntity(text, EntityType::StrikeOut);
 }
 
+TextWithEntities Code(const QString &text) {
+    return WithSingleEntity(text, EntityType::Code);
+}
+
 TextWithEntities Link(const QString &text, const QString &url) {
 	return WithSingleEntity(text, EntityType::CustomUrl, url);
 }

--- a/ui/text/text_utilities.h
+++ b/ui/text/text_utilities.h
@@ -21,6 +21,7 @@ class CustomEmoji;
 [[nodiscard]] TextWithEntities Italic(const QString &text);
 [[nodiscard]] TextWithEntities Underline(const QString &text);
 [[nodiscard]] TextWithEntities StrikeOut(const QString &text);
+[[nodiscard]] TextWithEntities Code(const QString &text);
 [[nodiscard]] TextWithEntities Link(
 	const QString &text,
 	const QString &url = u"internal:action"_q);

--- a/ui/widgets/checkbox.cpp
+++ b/ui/widgets/checkbox.cpp
@@ -16,7 +16,28 @@
 #include <QtGui/QtEvents>
 #include <QtCore/QtMath>
 
+#include "ayu/ayu_ui_settings.h"
+
 namespace Ui {
+namespace {
+
+int SwitchShift(not_null<const style::Toggle *> st) {
+	return AyuUiSettings::isMaterialSwitches() ? st->shift : st::defaultToggleShift;
+}
+
+int SwitchDiameter(not_null<const style::Toggle *> st) {
+	return AyuUiSettings::isMaterialSwitches() ? st->diameter : st::defaultToggleDiameter;
+}
+
+int SwitchDiameter(not_null<const style::Check *> st) {
+	return AyuUiSettings::isMaterialSwitches() ? st->diameter : st::defaultToggleDiameter;
+}
+
+int SwitchDiameter(not_null<const style::Radio *> st) {
+	return AyuUiSettings::isMaterialSwitches() ? st->diameter : st::defaultToggleDiameter;
+}
+
+} // namespace
 
 AbstractCheckView::AbstractCheckView(int duration, bool checked, Fn<void()> updateCallback)
 : _duration(duration)
@@ -37,7 +58,8 @@ void AbstractCheckView::setChecked(bool checked, anim::type animated) {
 			[=] { if (_updateCallback) _updateCallback(); },
 			_checked ? 0. : 1.,
 			_checked ? 1. : 0.,
-			_duration);
+			AyuUiSettings::isMaterialSwitches() ? _duration : st::defaultToggleDuration,
+			AyuUiSettings::isMaterialSwitches() ? anim::easeOutCubic : anim::linear);
 	}
 	checkedChangedHook(animated);
 	if (changed) {
@@ -76,7 +98,7 @@ ToggleView::ToggleView(
 }
 
 QSize ToggleView::getSize() const {
-	return QSize(2 * _st->border + _st->diameter + _st->width, 2 * _st->border + _st->diameter);
+	return QSize(2 * _st->border + SwitchDiameter(_st) + _st->width, 2 * _st->border + SwitchDiameter(_st));
 }
 
 void ToggleView::setStyle(const style::Toggle &st) {
@@ -89,13 +111,19 @@ void ToggleView::paint(QPainter &p, int left, int top, int outerWidth) {
 
 	PainterHighQualityEnabler hq(p);
 	auto toggled = currentAnimationValue();
-	auto fullWidth = _st->diameter + _st->width;
-	auto innerDiameter = _st->diameter - 2 * _st->shift;
+	auto fullWidth = SwitchDiameter(_st) + _st->width;
+	auto innerDiameter = SwitchDiameter(_st) - 2 * SwitchShift(_st);
 	auto innerRadius = float64(innerDiameter) / 2.;
-	auto toggleLeft = left + anim::interpolate(0, fullWidth - _st->diameter, toggled);
-	auto bgRect = style::rtlrect(left + _st->shift, top + _st->shift, fullWidth - 2 * _st->shift, innerDiameter, outerWidth);
-	auto fgRect = style::rtlrect(toggleLeft, top, _st->diameter, _st->diameter, outerWidth);
+	auto toggleLeft = left + anim::interpolate(0, fullWidth - SwitchDiameter(_st), toggled);
+	auto bgRect = style::rtlrect(left + SwitchShift(_st), top + SwitchShift(_st), fullWidth - 2 * SwitchShift(_st), innerDiameter, outerWidth);
+	auto fgRect = style::rtlrect(toggleLeft, top, SwitchDiameter(_st), SwitchDiameter(_st), outerWidth);
 	auto fgBrush = anim::brush(_st->untoggledFg, _st->toggledFg, toggled);
+
+	auto fgRectF = QRectF(fgRect);
+	if (AyuUiSettings::isMaterialSwitches()) {
+		const auto ayuToggleAnim = anim::interpolateToF(_st->animPadding, 0, toggled);
+		fgRectF.setRect(fgRectF.x() + ayuToggleAnim / 2., fgRectF.y() + ayuToggleAnim / 2., fgRectF.width() - ayuToggleAnim, fgRectF.height() - ayuToggleAnim);
+	}
 
 	p.setPen(Qt::NoPen);
 	p.setBrush(fgBrush);
@@ -105,7 +133,7 @@ void ToggleView::paint(QPainter &p, int left, int top, int outerWidth) {
 	pen.setWidth(_st->border);
 	p.setPen(pen);
 	p.setBrush(anim::brush(_st->untoggledBg, _st->toggledBg, toggled));
-	p.drawEllipse(fgRect);
+	p.drawEllipse(fgRectF);
 
 	if (_locked || _st->xsize > 0) {
 		p.setPen(Qt::NoPen);
@@ -127,8 +155,8 @@ void ToggleView::paintXV(QPainter &p, int left, int top, int outerWidth, float64
 	if (toggled < 1) {
 		// Just X or X->V.
 		const auto xSize = 0. + _st->xsize;
-		const auto xLeft = left + (_st->diameter - xSize) / 2.;
-		const auto xTop = top + (_st->diameter - xSize) / 2.;
+		const auto xLeft = left + (SwitchDiameter(_st) - xSize) / 2.;
+		const auto xTop = top + (SwitchDiameter(_st) - xSize) / 2.;
 		QPointF pathX[] = {
 			{ xLeft, xTop + stroke },
 			{ xLeft + stroke, xTop },
@@ -150,7 +178,7 @@ void ToggleView::paintXV(QPainter &p, int left, int top, int outerWidth, float64
 			// X->V.
 			const auto vSize = 0. + _st->vsize;
 			const auto fSize = (xSize + vSize - 2. * stroke);
-			const auto vLeft = left + (_st->diameter - fSize) / 2.;
+			const auto vLeft = left + (SwitchDiameter(_st) - fSize) / 2.;
 			const auto vTop = 0. + xTop + _st->vshift;
 			QPointF pathV[] = {
 				{ vLeft, vTop + xSize - vSize + stroke },
@@ -177,10 +205,10 @@ void ToggleView::paintXV(QPainter &p, int left, int top, int outerWidth, float64
 	} else {
 		// Just V.
 		const auto xSize = 0. + _st->xsize;
-		const auto xTop = top + (_st->diameter - xSize) / 2.;
+		const auto xTop = top + (SwitchDiameter(_st) - xSize) / 2.;
 		const auto vSize = 0. + _st->vsize;
 		const auto fSize = (xSize + vSize - 2. * stroke);
-		const auto vLeft = left + (_st->diameter - (_st->xsize + _st->vsize - 2. * stroke)) / 2.;
+		const auto vLeft = left + (SwitchDiameter(_st) - (_st->xsize + _st->vsize - 2. * stroke)) / 2.;
 		const auto vTop = 0. + xTop + _st->vshift;
 		QPointF pathV[] = {
 			{ vLeft, vTop + xSize - vSize + stroke },

--- a/ui/widgets/widgets.style
+++ b/ui/widgets/widgets.style
@@ -123,6 +123,7 @@ Toggle {
 	shift: pixels;
 	diameter: pixels;
 	width: pixels;
+	animPadding: pixels;
 	xsize: pixels;
 	vsize: pixels;
 	vshift: pixels;
@@ -870,16 +871,20 @@ defaultRadio: Radio {
 	duration: universalDuration;
 	rippleAreaPadding: 8px;
 }
+defaultToggleDuration: universalDuration;
+defaultToggleShift: 1px;
+defaultToggleDiameter: 16px;
 defaultToggle: Toggle {
 	toggledBg: windowBg;
 	toggledFg: windowBgActive;
 	untoggledBg: windowBg;
 	untoggledFg: checkboxFg;
-	duration: universalDuration;
+    duration: 150;
 	border: 2px;
-	shift: 1px;
-	diameter: 16px;
+	shift: -2px;
+	diameter: 14px;
 	width: 14px;
+	animPadding: 2px;
 	xsize: 0px;
 	vsize: 0px;
 	vshift: 0px;
@@ -942,7 +947,7 @@ roundShadowRadius8px: Shadow {
 defaultPanelAnimation: PanelAnimation {
 	startWidth: 0.5;
 	widthDuration: 0.6;
-	startHeight: 0.3;
+	startHeight: 0.45;
 	heightDuration: 0.9;
 	startOpacity: 0.2;
 	opacityDuration: 0.3;
@@ -1003,7 +1008,7 @@ defaultPopupMenu: PopupMenu {
 
 	menu: defaultMenu;
 
-	radius: 8px;
+	radius: 6px;
 	duration: 150;
 	showDuration: 200;
 }

--- a/ui/wrap/slide_wrap.cpp
+++ b/ui/wrap/slide_wrap.cpp
@@ -65,7 +65,7 @@ SlideWrap<RpWidget> *SlideWrap<RpWidget>::toggle(
 				_toggled ? 0. : 1.,
 				_toggled ? 1. : 0.,
 				_duration,
-				anim::linear);
+				ease);
 			if (_finishedCallback) {
 				_animation.setFinishedCallback(_finishedCallback);
 			}

--- a/ui/wrap/slide_wrap.h
+++ b/ui/wrap/slide_wrap.h
@@ -58,6 +58,9 @@ public:
 
 	QMargins getMargins() const override;
 
+	// I don't care about this being public
+	anim::transition ease = anim::linear;
+
 protected:
 	int resizeGetHeight(int newWidth) override;
 	void wrappedSizeUpdated(QSize size) override;


### PR DESCRIPTION
> This pull request was generated by AI.

## What changed

- Updated the AyuGram `lib_ui` line to upstream `desktop-app/lib_ui` revision `07cea400e2e6b2a7c08a289472bf5976a77e6500`, used by Telegram Desktop 7.0.5.
- Reapplied and adapted the AyuGram UI layer, including Ayu settings, font/material switches, avatar handling, quote styling, entity flags, and slide easing.
- Kept the upstream UI and accessibility changes required by the matching Telegram Desktop source tree.

## Why

The Telegram Desktop 7.0.5 integration in AyuGramDesktop requires the current `lib_ui` API. Pointing the superproject at upstream directly removed Ayu-specific UI contracts, while keeping the previous Ayu commit did not provide the new Telegram interfaces. This branch combines both sides into one buildable tree.

## Validation

- `lib_ui.vcxproj` compiled successfully as part of a clean Windows x64 Release build on `ai-station`.
- The dependent AyuGramDesktop build, link, unsigned installer packaging, isolated installation, and 12-second launch smoke test all completed with exit code 0.
- Tested installer SHA-256: `CF00E988911075EC185FC6224965994B5AA1D7BF386B5C7D467847CE1A976DB1`.
- The user manually tested the resulting installer and reported that everything appeared to work.

The corresponding AyuGramDesktop pull request will reference this dependency.
